### PR TITLE
Feature/improve setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,40 @@ The main functionality of this package is:
 - Generate Livewire forms (Show, Create, Update) by using one command and one Livewire component.
 
 ## Requirements
-The following points are required to install this package:
-- PHP 8.0+
-- Laravel [10.x, 9.x]
-- Laravel Livewire 2.x
-- Alpine.js 3.x
-- Tailwindcss 3.x
-> Note that the following npm packages is required only if you have a date field within your form.
-- pikaday: 1.x
-- moment: 2.x
+The following dependencies are required to use the package:
+
+| Dependency  | Version                                        |     |
+|:------------|:-----------------------------------------------|:----|
+| PHP         | [8.x](https://www.php.net/releases/8.0/en.php) |     |
+| Laravel     | [10.x, 9.x](https://laravel.com/docs/10.x)     |     |
+| Jetstream   | [3.x](https://jetstream.laravel.com/)          | 💡  |
+| Livewire    | [2.x](https://laravel-livewire.com/docs/2.x)   | 💡  |
+| Alpine.js   | [3.x](https://alpinejs.dev/)                   | 💡  |
+| TailwindCSS | [3.x](https://tailwindcss.com/docs)            | 💡  |
+| Pikaday     | [1.x](https://github.com/Pikaday/Pikaday)      | 💡  |
+| Moment      | [2.x](https://momentjs.com/docs/)              | 💡  |
+
+💡 => You can install it with Auto Setup & Configuration.
+> Note that (pikaday & moment) npm packages is required only if you have a date field within your form.
+
 ## Installation
 
-For now while the package is in development phase and not released yet, in order to use it you must add these line to your `composer.json` file:
-
-```
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/wisam-alhennawi/lara-forms-builder.git"
-        }
-    ]
-```
-> Note that each one of the following commands has two option for execution first with laravel sail & second with default laravel.
-
-After that run:
-
 ```bash
-sail composer require wisam-alhennawi/lara-forms-builder
 composer require wisam-alhennawi/lara-forms-builder
 ```
+
+## Auto Setup & Configuration
+```bash
+php artisan make:lara-forms-builder-setup
+```
+
+This command will do the following:
+- Install `"laravel/jetstream": "^3.0"` with `"livewire/livewire": "^2.0"` if not installed. Installing jetstream will install `"tailwindcss": "^3.0"` & `"alpinejs": "^3.0"`.
+- Install `"pikaday": "^1.0"` and `"moment": "^2.0"` npm packages and make required configuration.
+- Add confirmation modal component to `app.blade.php` layout.
+- publish `lara-forms-builder.php` config file and make required configuration.
+- publish `lara-forms-builder.css` assets file and make required configuration.
+- Run `npm install` & `npm run build`.
 
 ## Configuration
 
@@ -95,23 +100,13 @@ composer require wisam-alhennawi/lara-forms-builder
 
 3) #### Translation (optional)
     ```bash
-    sail artisan vendor:publish --tag="lara-forms-builder-translations"
     php artisan vendor:publish --tag="lara-forms-builder-translations"
     ```
 
 4) #### Views (optional)
     ```bash
-    sail artisan vendor:publish --tag="lara-forms-builder-views"
     php artisan vendor:publish --tag="lara-forms-builder-views"
     ```
-
-### Alpine.js Cloak **(Mandatory)**
-You must also make sure you have this Alpine style available globally:
-```
-<style>
-    [x-cloak] { display: none !important; }
-</style>
-```
 
 ### Using date in form (optional)
 Like it mention in the Requirements section if your form has a date field you must install required dependencies by following these steps:
@@ -135,6 +130,10 @@ Like it mention in the Requirements section if your form has a date field you mu
     sail npm install moment
     npm install moment
     ```
+### Use confirmation modal
+
+In order to use the confirmation modal within your project you must include it globally in the default layout of your blade view where you want to use it.
+So you can add `@livewire('modals.confirmation')` to your `views/layouts/app.blade.php` inside the html `<body>` tag.
 
 ## Usage
 
@@ -143,21 +142,14 @@ Like it mention in the Requirements section if your form has a date field you mu
 By using this command you can create a new Livewire form depending on a model,
 additionally you can add [--langModelFileName=] tag to specify a lang file for model fields labels:
 ```bash
-sail artisan make:lara-forms-builder [Component Name] [Model] [--langModelFileName=]
-php artisan make:lara-forms-builder [Component Name] [Model] [--langModelFileName=]
+php artisan make:lara-forms-builder name model --langModelFileName=
 ```
 
 Examples:
 ```bash
-sail artisan make:lara-forms-builder UserForm User --langModelFileName=users
-sail artisan make:lara-forms-builder Users.UserForm User --langModelFileName=users       //this will make a UserForm component inside Users directory.
+php artisan make:lara-forms-builder UserForm User --langModelFileName=users
+php artisan make:lara-forms-builder Users.UserForm User --langModelFileName=users       //this will make a UserForm component inside Users directory.
 ```
-
-### Use confirmation modal
-
-In order to use the confirmation modal within your project you must include it globally in the default layout of your blade view where you want to use it.
-So you can add `@livewire('modals.confirmation')` to your `views/layouts/app.blade.php` inside the html `<body>` tag.
-
 
 ## Changelog
 

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -6,6 +6,7 @@ use Composer\InstalledVersions;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class LaraFormsBuilderSetupCommand extends Command
@@ -15,7 +16,7 @@ class LaraFormsBuilderSetupCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'make:lara-forms-builder-setup';
+    protected $signature = 'make:lara-forms-builder-setup {--stv}';
 
     /**
      * The console command description.
@@ -57,6 +58,7 @@ class LaraFormsBuilderSetupCommand extends Command
 
     protected function checkEnvironment(): void
     {
+        Log::info('LFB Jetstream = ' . InstalledVersions::isInstalled('laravel/jetstream'));
         //check if jetstream version 3 installed
         if (InstalledVersions::isInstalled('laravel/jetstream')) {
             $jetstreamVersion = InstalledVersions::getVersion('laravel/jetstream');
@@ -119,6 +121,9 @@ class LaraFormsBuilderSetupCommand extends Command
 
     protected function installJetstream(): void
     {
+        if ($this->option('stv')) {
+            $this->checkEnvironment();
+        }
         if (! $this->isJetstreamInstalled) {
             if ($this->components->confirm('This Package Requires (laravel/jetstream:^3.0 with livewire/livewire:^2.0) Do You Want To Install them ?', true)) {
                 try {

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -121,10 +121,7 @@ class LaraFormsBuilderSetupCommand extends Command
 
     protected function installJetstream(): void
     {
-        if ($this->option('stv')) {
-            $this->checkEnvironment();
-        }
-        if (! $this->isJetstreamInstalled) {
+        if (! $this->option('stv') && ! $this->isJetstreamInstalled) {
             if ($this->components->confirm('This Package Requires (laravel/jetstream:^3.0 with livewire/livewire:^2.0) Do You Want To Install them ?', true)) {
                 try {
                     exec('composer require laravel/jetstream:^3.0');

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use SchwingeGmbH\SchwingeTallViews\Traits\WorkingWithStringsInFilesTrait;
+use WisamAlhennawi\LaraFormsBuilder\Traits\WorkingWithStringsInFilesTrait;
 
 class LaraFormsBuilderSetupCommand extends Command
 {

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -8,9 +8,12 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use SchwingeGmbH\SchwingeTallViews\Traits\WorkingWithStringsInFilesTrait;
 
 class LaraFormsBuilderSetupCommand extends Command
 {
+    use WorkingWithStringsInFilesTrait;
+
     /**
      * The name and signature of the console command.
      *
@@ -147,12 +150,11 @@ class LaraFormsBuilderSetupCommand extends Command
             $this->call('vendor:publish', ['--tag' => 'lara-forms-builder-config', '--force' => true]);
             $this->components->info('(lara-forms-builder-config) published successfully.');
             // add lara-forms-builder-config to the content[] in tailwind.config.js
-            (new Filesystem)
-                ->replaceInFile(
-                    "'./resources/views/**/*.blade.php',",
-                    "'./resources/views/**/*.blade.php',\n        './config/lara-forms-builder.php',",
-                    base_path('tailwind.config.js')
-                );
+            $this->insertInFile(
+                "'./resources/views/**/*.blade.php',",
+                "'./config/lara-forms-builder.php',",
+                base_path('tailwind.config.js')
+            );
         }
     }
 
@@ -169,22 +171,31 @@ class LaraFormsBuilderSetupCommand extends Command
                 );
 
             // update the colors{} object in tailwind.config.js
-            (new Filesystem)
-                ->replaceInFile(
-                    "            fontFamily: {
-                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
-            },",
-                    '            fontFamily: {'."\n".
-                           "                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],"."\n".
-                           '            },'."\n".
-                           '            colors: {'."\n".
-                           "                'primary': '', // #7c8e63"."\n".
-                           "                'secondary': '', // #aebf85"."\n".
-                           "                'danger': '' // #DC3545"."\n".
-                           '            },',
-
-                    base_path('tailwind.config.js')
-                );
+            $this->insertInFile(
+                "sans: ['Figtree', ...defaultTheme.fontFamily.sans],".PHP_EOL."},",
+                '            colors: {'.PHP_EOL.
+                      "                'primary': '', // #7c8e63".PHP_EOL.
+                      "                'secondary': '', // #aebf85".PHP_EOL.
+                      "                'danger': '' // #DC3545".PHP_EOL.
+                      '            },',
+                base_path('tailwind.config.js')
+            );
+//            (new Filesystem)
+//                ->replaceInFile(
+//                    "            fontFamily: {
+//                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+//            },",
+//                    '            fontFamily: {'."\n".
+//                           "                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],"."\n".
+//                           '            },'."\n".
+//                           '            colors: {'."\n".
+//                           "                'primary': '', // #7c8e63"."\n".
+//                           "                'secondary': '', // #aebf85"."\n".
+//                           "                'danger': '' // #DC3545"."\n".
+//                           '            },',
+//
+//                    base_path('tailwind.config.js')
+//                );
         }
     }
 
@@ -192,12 +203,11 @@ class LaraFormsBuilderSetupCommand extends Command
     {
         if (! $this->isConfirmationModalIncluded) {
             if ($this->components->confirm('Do you want to include confirmation modal in app.blade layout?', true)) {
-                (new Filesystem)
-                    ->replaceInFile(
-                        "@livewire('navigation-menu')",
-                        "@livewire('navigation-menu') \n            @livewire('modals.confirmation')",
-                        resource_path('views/layouts/app.blade.php')
-                    );
+                $this->insertInFile(
+                    "@livewire('navigation-menu')",
+                    "@livewire('modals.confirmation')",
+                    resource_path('views/layouts/app.blade.php')
+                );
             }
         }
     }

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -112,30 +112,30 @@ class LaraFormsBuilderSetupCommand extends Command
     protected function runInstallations(): void
     {
         $this->installJetstream();
+        $this->installPikadayAndMoment();
+        $this->includeConfirmationModal();
         $this->publishLaraFormsBuilderConfigFile();
         $this->publishLaraFormsBuilderCSSFile();
-        $this->includeConfirmationModal();
-        $this->installPikadayAndMoment();
         $this->npmActions();
     }
 
     protected function installJetstream(): void
     {
         if (! $this->option('stv') && ! $this->isJetstreamInstalled) {
-            if ($this->components->confirm('This Package Requires (laravel/jetstream:^3.0 with livewire/livewire:^2.0) Do You Want To Install them ?', true)) {
+            if ($this->components->confirm('This package qequires (laravel/jetstream:^3.0 with livewire/livewire:^2.0). Do you want to install them?', true)) {
                 try {
                     exec('composer require laravel/jetstream:^3.0');
                     exec('php artisan jetstream:install livewire');
                     exec('php artisan migrate');
 
                     $this->line('');
-                    $this->components->info('<options=bold,reverse;fg=green> Jetstream with livewire installed successfully & DB migrated </>');
+                    $this->components->info('(laravel/jetstream:^3.0 with livewire/livewire:^2.0) installed successfully.');
                 } catch (\Throwable $e) {
-                    $this->components->error('Jetstream with livewire installation ERROR');
+                    $this->components->error('(laravel/jetstream:^3.0 with livewire/livewire:^2.0) installation ERROR.');
                     exit;
                 }
             } else {
-                $this->components->warn('Installation Aborted Because Required Packages Not Installed');
+                $this->components->warn('Installation aborted because required packages not installed.');
                 exit;
             }
         }
@@ -145,7 +145,7 @@ class LaraFormsBuilderSetupCommand extends Command
     {
         if (! $this->isLaraFormsBuilderConfigFilePublished) {
             $this->call('vendor:publish', ['--tag' => 'lara-forms-builder-config', '--force' => true]);
-
+            $this->components->info('(lara-forms-builder-config) published successfully.');
             // add lara-forms-builder-config to the content[] in tailwind.config.js
             (new Filesystem)
                 ->replaceInFile(
@@ -153,8 +153,6 @@ class LaraFormsBuilderSetupCommand extends Command
                     "'./resources/views/**/*.blade.php',\n        './config/lara-forms-builder.php',",
                     base_path('tailwind.config.js')
                 );
-
-            $this->components->info('<options=bold,reverse;fg=green> (lara-forms-builder-config) published successfully & added to tailwind.config.js </>');
         }
     }
 
@@ -162,7 +160,7 @@ class LaraFormsBuilderSetupCommand extends Command
     {
         if (! $this->isLaraFormsBuilderCSSFilePublished) {
             $this->call('vendor:publish', ['--tag' => 'lara-forms-builder-assets', '--force' => true]);
-
+            $this->components->info('(lara-forms-builder-assets) published successfully.');
             // import lara-forms-builder-assets in app.css
             (new Filesystem)
                 ->prepend(
@@ -187,22 +185,19 @@ class LaraFormsBuilderSetupCommand extends Command
 
                     base_path('tailwind.config.js')
                 );
-
-            $this->components->info('<options=bold,reverse;fg=green> (lara-forms-builder-assets) published successfully & imported in /resource/css/app.css & colors added in tailwind.config.js </>');
         }
     }
 
     protected function includeConfirmationModal(): void
     {
         if (! $this->isConfirmationModalIncluded) {
-            if ($this->components->confirm('Do You Want To Include Modal in app.blade layout ?', true)) {
+            if ($this->components->confirm('Do you want to include confirmation modal in app.blade layout?', true)) {
                 (new Filesystem)
                     ->replaceInFile(
                         "@livewire('navigation-menu')",
                         "@livewire('navigation-menu') \n            @livewire('modals.confirmation')",
                         resource_path('views/layouts/app.blade.php')
                     );
-                $this->components->info('<options=bold,reverse;fg=green> Confirmation modal included successfully </>');
             }
         }
     }
@@ -210,7 +205,7 @@ class LaraFormsBuilderSetupCommand extends Command
     protected function installPikadayAndMoment(): void
     {
         if (! $this->isPikadayInstalled || ! $this->isMomentInstalled) {
-            if ($this->components->confirm('Do You Want To Install and config (pikaday & moment) npm packages, These packages are required to use date fields in lara-forms-builder ?', true)) {
+            if ($this->components->confirm('Do you want to install and config (pikaday & moment) npm packages, These packages are required to use date fields in lara-forms-builder?', true)) {
                 $data = json_decode(file_get_contents(base_path('package.json')), true);
                 if (! $this->isPikadayInstalled) {
                     $data['devDependencies']['pikaday'] = '^1.8.2';
@@ -220,6 +215,7 @@ class LaraFormsBuilderSetupCommand extends Command
                 }
 
                 file_put_contents(base_path('package.json'), json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+                $this->components->info('(pikaday & moment) packages added to package.json successfully.');
 
                 // config pikaday in app.js
                 (new Filesystem)
@@ -234,8 +230,6 @@ class LaraFormsBuilderSetupCommand extends Command
                         resource_path('/css/app.css'),
                         '@import "pikaday/css/pikaday.css";'."\n"
                     );
-
-                $this->components->info('<options=bold,reverse;fg=green> (pikaday & moment) packages added to package.json successfully & imported in (app.js & app.css) </>');
             }
         }
     }
@@ -243,9 +237,9 @@ class LaraFormsBuilderSetupCommand extends Command
     protected function npmActions(): void
     {
         try {
-            $this->components->info('<options=bold,reverse;fg=green> Running npm install & npm run build </>');
             $this->info(exec('npm install'));
             $this->info(exec('npm run build'));
+            $this->components->info('npm install & npm run build executed successfully.');
         } catch (\Throwable $e) {
             $this->components->error('(npm install & npm run build) ERROR');
             exit;

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -152,7 +152,7 @@ class LaraFormsBuilderSetupCommand extends Command
             // add lara-forms-builder-config to the content[] in tailwind.config.js
             $this->insertInFile(
                 "'./resources/views/**/*.blade.php',",
-                "'./config/lara-forms-builder.php',",
+                "        './config/lara-forms-builder.php',",
                 base_path('tailwind.config.js')
             );
         }
@@ -172,7 +172,7 @@ class LaraFormsBuilderSetupCommand extends Command
 
             // update the colors{} object in tailwind.config.js
             $this->insertInFile(
-                "sans: ['Figtree', ...defaultTheme.fontFamily.sans],".PHP_EOL."},",
+                "sans: ['Figtree', ...defaultTheme.fontFamily.sans],".PHP_EOL."            },",
                 '            colors: {'.PHP_EOL.
                       "                'primary': '', // #7c8e63".PHP_EOL.
                       "                'secondary': '', // #aebf85".PHP_EOL.
@@ -180,22 +180,6 @@ class LaraFormsBuilderSetupCommand extends Command
                       '            },',
                 base_path('tailwind.config.js')
             );
-//            (new Filesystem)
-//                ->replaceInFile(
-//                    "            fontFamily: {
-//                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
-//            },",
-//                    '            fontFamily: {'."\n".
-//                           "                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],"."\n".
-//                           '            },'."\n".
-//                           '            colors: {'."\n".
-//                           "                'primary': '', // #7c8e63"."\n".
-//                           "                'secondary': '', // #aebf85"."\n".
-//                           "                'danger': '' // #DC3545"."\n".
-//                           '            },',
-//
-//                    base_path('tailwind.config.js')
-//                );
         }
     }
 
@@ -205,7 +189,7 @@ class LaraFormsBuilderSetupCommand extends Command
             if ($this->components->confirm('Do you want to include confirmation modal in app.blade layout?', true)) {
                 $this->insertInFile(
                     "@livewire('navigation-menu')",
-                    "@livewire('modals.confirmation')",
+                    "            @livewire('modals.confirmation')",
                     resource_path('views/layouts/app.blade.php')
                 );
             }

--- a/src/Traits/WorkingWithStringsInFilesTrait.php
+++ b/src/Traits/WorkingWithStringsInFilesTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SchwingeGmbH\SchwingeTallViews\Traits;
+
+trait WorkingWithStringsInFilesTrait
+{
+    public function insertInFile($search, $insert, $path, $after = true): ?bool
+    {
+        $errorMsg = "Couldn't add '".trim($insert)."' to '$path'. Please add it manually.";
+
+        // check if the file not exists
+        if (! file_exists($path)) {
+            return $this->components->warn($errorMsg);
+        }
+        // check if the file already has the $string
+        if (str_contains($fileContentsAsString = file_get_contents($path), $insert)) {
+            return true;
+        }
+        // check if the $keyword we want to add $string after it not in the file
+        if (! str_contains($fileContentsAsString, $search)) {
+            return $this->components->warn($errorMsg);
+        }
+
+        if ($after) {
+            file_put_contents($path, substr_replace($fileContentsAsString, PHP_EOL.$insert, strpos($fileContentsAsString, $search) + strlen($search), 0));
+        } else {
+            file_put_contents($path, substr_replace($fileContentsAsString, $insert.PHP_EOL, strpos($fileContentsAsString, $search), 0));
+        }
+
+        return str_contains(file_get_contents($path), $insert) ?? $this->components->warn($errorMsg);
+    }
+
+    public function replaceInFile($search, $replace, $path): ?bool
+    {
+        $errorMsg = "Couldn't replace \"".trim($search).'" with "'.trim($replace)."\" in $path Please replace it manually.";
+
+        // check if the file not exists
+        if (! file_exists($path)) {
+            return $this->components->warn($errorMsg);
+        }
+        // check if the file already has the string $replace
+        if (str_contains($fileContentsAsString = file_get_contents($path), $replace)) {
+            return true;
+        }
+        // check if the string $search we want to replace it with $replace not in the file
+        if (! str_contains($fileContentsAsString, $search)) {
+            return $this->components->warn($errorMsg);
+        }
+
+        file_put_contents($path, str_replace($search, $replace, $fileContentsAsString));
+
+        return str_contains(file_get_contents($path), $replace) ?? $this->components->warn($errorMsg);
+    }
+}

--- a/src/Traits/WorkingWithStringsInFilesTrait.php
+++ b/src/Traits/WorkingWithStringsInFilesTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SchwingeGmbH\SchwingeTallViews\Traits;
+namespace WisamAlhennawi\LaraFormsBuilder\Traits;
 
 trait WorkingWithStringsInFilesTrait
 {


### PR DESCRIPTION
Hi Wisam, 
In this PR I did the following:

1. Define a new trait `WorkingWithStringsInFilesTrait.php` contains two functions:
   - `insertInFile()`.
   - `replaceInFile()`.
2. Use the functions above in `LaraFormsBuilderSetupCommand.php`.
3. add `--stv` flag to the setup command to check if it is called from `SchwingeTallViewsSetupCommand.php` so we can skip jetstream installation.
4. Update `README.md`.
