### PR TITLE
Html in labels, div-based select

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The definition above is then rendered as displayed in this screenshot (with addi
 All form components have the following general properties:
 
 * `type` (mandatory): Specifies the kind of form component, see the following subsections for supported types and their individual properties
-* `label` (mandatory): Label text of the component
+* `label` (mandatory): Label text of the component, can also include HTML tags (please handle responsibly and do not allow user input to be used as labels)
 * `validationAttribute` (optional): If set, the value will be used as the attribute label for validation messages. If not set, the `label` is also used as a field name for validation messages.
 * `helpText` (optional): Help text displayed at the bottom of the component
 * `readOnly` (optional): When set to true, the form field does not allow input or changes and only displays the current value

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ The `select` form field is a select box for single selection. It has the followi
 
 * `options` (mandatory): Specifies the options to be displayed in the select box, provided as an array of objects with attributes `value` and `label` or a nested array of group label to array of objects with attributes `value` and `label` when grouped.
 * `isGrouped` (optional): Defines whether the options are grouped, default when not set is false.
+* `styled` (optional, not combinable with `isGrouped`): When set to true, uses a stylable div based select component instead of the html select element.
+* `searchable` (optional, only when `styled` is `true`): When set to true, adds a search field that allows to filter the options for search expressions (simple case insensitive substring matching)
 
 #### Type `radio`
 

--- a/resources/dist/css/lara-forms-builder.css
+++ b/resources/dist/css/lara-forms-builder.css
@@ -285,4 +285,47 @@
         @apply py-0.5 rounded border px-2 text-sm border-gray-200 bg-gray-100 text-gray-500
     }
 
+    .lfb-styled-select-input {
+        @apply flex border;
+    }
+
+    .lfb-styled-select-input-collapsed {
+        @apply border-transparent;
+    }
+
+    .lfb-styled-select-input-expanded {
+        @apply border-primary ring-1 ring-primary rounded-md rounded-b-none shadow-sm;
+    }
+
+    .lfb-styled-select-options {
+        @apply bg-white w-full border border-t-0 border-primary ring-1 ring-primary rounded-md rounded-t-none;
+    }
+
+    .lfb-styled-select-options ul {
+        @apply text-sm divide-y max-h-24 overflow-x-hidden overflow-y-auto;
+    }
+
+    .lfb-styled-select-options li {
+        @apply cursor-pointer rounded py-1 px-3 hover:bg-gray-50;
+    }
+
+    .lfb-styled-select-search-container {
+        @apply flex bg-gray-100 rounded-b;
+    }
+
+    .lfb-styled-select-search-icon-wrapper {
+        @apply flex pt-2.5 pl-3;
+    }
+
+    .lfb-styled-select-search-icon {
+        @apply text-gray-500 w-4 h-4;
+    }
+
+    .lfb-styled-select-search-input {
+        @apply flex flex-grow border-0 bg-transparent py-2 pl-3 text-sm focus:outline-none focus:ring-0;
+    }
+
+    .lfb-styled-select-search-button {
+        @apply flex border-t pt-2.5 px-3 focus:outline-none;
+    }
 }

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -36,5 +36,6 @@
     "Sun": "So",
     "Previous Month": "Vormonat",
     "Next Month": "Folgemonat",
-    "Select File": "Datei auswählen"
+    "Select File": "Datei auswählen",
+    "Search": "Suche"
 }

--- a/resources/views/components/checkbox-group.blade.php
+++ b/resources/views/components/checkbox-group.blade.php
@@ -1,10 +1,5 @@
 <div class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     <div class="lfb-fieldset lfb-fieldset-container">
         <div class="lfb-checkbox-group">
             @if($hasCategory)

--- a/resources/views/components/date-picker.blade.php
+++ b/resources/views/components/date-picker.blade.php
@@ -11,12 +11,7 @@
 @endonce
 
 <div class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @if (isset($mode) && ($mode == 'view' || $mode == 'confirm'))
         <div class="lfb-input-wrapper lfb-input-readonly">
             <input type="text" name="{{ $key }}" id="{{ $key }}" x-ref="field"

--- a/resources/views/components/file-upload.blade.php
+++ b/resources/views/components/file-upload.blade.php
@@ -1,10 +1,5 @@
 <div class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required|'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @if (isset($mode) && ($mode == 'view' || $mode == 'confirm'))
         <div class="lfb-input-wrapper lfb-input-readonly">
             @if ((isset($preview) && $preview) && ($model->$key || isset($this->{$key . '_preview'})))

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,10 +1,5 @@
 <div class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required|'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @if (isset($mode) && ($mode == 'view' || $mode == 'confirm'))
         <div class="lfb-input-wrapper lfb-input-readonly">
             <input type="@if(isset($inputType)){{$inputType}}@else{{'text'}}@endif" name="{{ $key }}" id="{{ $key }}"

--- a/resources/views/components/radio.blade.php
+++ b/resources/views/components/radio.blade.php
@@ -1,10 +1,5 @@
 <div class="@if (isset($fieldWrapperClass)) {{$fieldWrapperClass}} @endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @if (isset($mode) && ($mode == 'view' || $mode == 'confirm'))
         @if ($model->$key && array_key_exists(is_object($model->$key) && enum_exists($model->$key::class) ? $model->$key->value : $model->$key, $radioOptions))
             @php

--- a/resources/views/components/search-picker.blade.php
+++ b/resources/views/components/search-picker.blade.php
@@ -8,12 +8,7 @@
      @click.outside="showResults = false"
      class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif"
 >
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required|'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @if (isset($mode) && ($mode == 'view' || $mode == 'confirm'))
         <div class="lfb-input-wrapper lfb-input-readonly">
             <input

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -35,6 +35,78 @@
         </div>
     @else
         <div class="lfb-input-wrapper">
+            @if($styled)
+            @include('lara-forms-builder::includes.select-script')
+            <div
+                x-data="lfbStyledSelect({ data: {{ json_encode($selectOptions) }}, preselected: '@if(is_numeric($optionKey) && array_key_exists($optionKey, $selectOptions)){{ $selectOptions[$optionKey]['label'] }}@endif' })"
+                wire:model="{{ $key }}"
+                class="relative lfb-input"
+                wire:key="form-select-component-{{ md5($key) }}"
+            >
+                <div
+                    class="lfb-styled-select-input"
+                    :class="show ? 'lfb-styled-select-input-expanded': 'lfb-styled-select-input-collapsed'"
+                >
+                    <div class="flex flex-grow py-2 px-3" x-on:click="open()">
+                        <div x-text="selected">&nbsp;</div>
+                        <div x-show="selected.length == 0" x-text="placeholder" class="text-gray-400">&nbsp;</div>
+                    </div>
+                    <div class="flex">
+                        <div x-on:click="toggle()" class="pt-2.5 px-3">
+                            <div x-show="!show && !selected" class="w-4 h-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                                </svg>
+                            </div>
+                            <div x-cloak x-show="show && !selected" class="w-4 h-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+                                </svg>
+                            </div>
+                        </div>
+                        <button x-cloak x-show="selected.length > 0" x-on:click="removeSelected(), $dispatch('input', null)" class="px-3">
+                            <!-- heroicon:x-mark -->
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <div x-cloak x-show="show" x-on:click.outside="close()" class="absolute z-10 lfb-styled-select-options">
+                    @if ($searchable)
+                    <div class="lfb-styled-select-search-container">
+                        <div class="lfb-styled-select-search-icon-wrapper">
+                            <div class="lfb-styled-select-search-icon">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                                </svg>
+                            </div>
+                        </div>
+                        <input
+                            type="text"
+                            x-model="search"
+                            class="lfb-styled-select-search-input"
+                            placeholder="{{ __('Search') }}"
+                        >
+                        <button class="lfb-styled-select-search-button" x-on:click="resetSearch()">
+                            <div x-show="search.length > 0"  class="w-4 h-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                                </svg>
+                            </div>
+                        </button>
+                    </div>
+                    @endif
+                    <ul>
+                        <template x-for="item in filteredOptions" :key="item.value">
+                            <li x-on:click="selectOption(item.label); $dispatch('input', item.value)"
+                                x-text="item.label">
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+            </div>
+            @else
             <select id="{{ $key }}" name="{{ $key }}" class="lfb-input"
                     wire:model="{{ $key }}">
                 <option value>{{ __('Please select...') }}</option>
@@ -52,6 +124,7 @@
                     @endforeach
                 @endif
             </select>
+            @endif
         </div>
         @error($key) <span class="lfb-alert lfb-alert-error">{{ $message }}</span> @enderror
         @if(isset($helpText))

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,10 +1,5 @@
 <div class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view'))  and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @php
         $fieldValue = $model->$key->value ?? $model->$key;
         if ($isGrouped) {

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -38,33 +38,34 @@
             @if($styled)
             @include('lara-forms-builder::includes.select-script')
             <div
-                x-data="lfbStyledSelect({ data: {{ json_encode($selectOptions) }}, preselected: '@if(is_numeric($optionKey) && array_key_exists($optionKey, $selectOptions)){{ $selectOptions[$optionKey]['label'] }}@endif' })"
-                wire:model="{{ $key }}"
+                x-data="{ ...lfbStyledSelect({{ json_encode($selectOptions) }}), value: @entangle($key) }"
                 class="relative lfb-input"
                 wire:key="form-select-component-{{ md5($key) }}"
+                name="{{ $key }}"
+                id="{{ $key }}"
             >
                 <div
                     class="lfb-styled-select-input"
                     :class="show ? 'lfb-styled-select-input-expanded': 'lfb-styled-select-input-collapsed'"
                 >
                     <div class="flex flex-grow py-2 px-3" x-on:click="open()">
-                        <div x-text="selected">&nbsp;</div>
-                        <div x-show="selected.length == 0" x-text="placeholder" class="text-gray-400">&nbsp;</div>
+                        <div x-text="selectedLabel">&nbsp;</div>
+                        <div x-show="!value" x-text="placeholder" class="text-gray-400">&nbsp;</div>
                     </div>
                     <div class="flex">
                         <div x-on:click="toggle()" class="pt-2.5 px-3">
-                            <div x-show="!show && !selected" class="w-4 h-4">
+                            <div x-show="!show && !value" class="w-4 h-4">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
                                 </svg>
                             </div>
-                            <div x-cloak x-show="show && !selected" class="w-4 h-4">
+                            <div x-cloak x-show="show && !value" class="w-4 h-4">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
                                 </svg>
                             </div>
                         </div>
-                        <button x-cloak x-show="selected.length > 0" x-on:click="removeSelected(), $dispatch('input', null)" class="px-3">
+                        <button x-cloak x-show="value" x-on:click="removeSelected()" class="px-3">
                             <!-- heroicon:x-mark -->
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -99,7 +100,7 @@
                     @endif
                     <ul>
                         <template x-for="item in filteredOptions" :key="item.value">
-                            <li x-on:click="selectOption(item.label); $dispatch('input', item.value)"
+                            <li x-on:click="selectOption(item)"
                                 x-text="item.label">
                             </li>
                         </template>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,10 +1,5 @@
 <div class="@if(isset($fieldWrapperClass)){{$fieldWrapperClass}}@endif">
-    <label for="{{ $key }}" class="lfb-label">
-        {{ $label }}
-        @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules) and array_key_exists($key, $rules) && str_contains($rules[$key], 'required|'))
-            <sup>*</sup>
-        @endif
-    </label>
+    @include('lara-forms-builder::includes.field-label')
     @if (isset($mode) && ($mode == 'view' || $mode == 'confirm'))
         <div class="lfb-input-wrapper lfb-input-readonly">
             <textarea name="form-textarea-component-{{ $key }}" id="form-textarea-component-{{ $key }}"

--- a/resources/views/form-components.blade.php
+++ b/resources/views/form-components.blade.php
@@ -18,6 +18,8 @@
             'isGrouped' => isset($field['isGrouped']) ? $field['isGrouped'] : false,
             'helpText' => isset($field['helpText']) ? $field['helpText'] : '',
             'readOnly' => isset($field['readOnly']) ? $field['readOnly'] : false,
+            'styled' => isset($field['styled']) ? $field['styled'] : false,
+            'searchable' => isset($field['searchable']) ? $field['searchable'] : false,
             'fieldWrapperClass' => isset($field['field_wrapper_class']) ? $field['field_wrapper_class'] : $defaultFieldWrapperClass
         ])
         @break

--- a/resources/views/includes/checkboxGroupOptions.blade.php
+++ b/resources/views/includes/checkboxGroupOptions.blade.php
@@ -4,6 +4,6 @@
               wire:model="{{ $key }}" class="lfb-checkbox @if(isset($option['disabled']) && $option['disabled']) lfb-disabled @endif"
               @if ((isset($mode) && ($mode == 'view' || $mode == 'confirm')) || (isset($option['disabled']) && $option['disabled'])) disabled @endif>
        <label class="lfb-label lfb-label-spacing print:text-xs" for="{{ $key }}.{{ $option['value'] }}">
-              {{ $option['label'] }}
+              {!! $option['label'] !!}
        </label>
 </div>

--- a/resources/views/includes/field-label.blade.php
+++ b/resources/views/includes/field-label.blade.php
@@ -1,0 +1,7 @@
+<label for="{{ $key }}" class="lfb-label">
+    {!! $label !!}
+    @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules)
+        and array_key_exists($key, $rules) && str_contains($rules[$key], 'required|'))
+        <sup>*</sup>
+    @endif
+</label>

--- a/resources/views/includes/field-label.blade.php
+++ b/resources/views/includes/field-label.blade.php
@@ -1,7 +1,7 @@
 <label for="{{ $key }}" class="lfb-label">
     {!! $label !!}
     @if ((!isset($mode) || (isset($mode) and $mode != 'view')) and isset($rules)
-        and array_key_exists($key, $rules) && str_contains($rules[$key], 'required|'))
+        and array_key_exists($key, $rules) && str_contains($rules[$key], 'required'))
         <sup>*</sup>
     @endif
 </label>

--- a/resources/views/includes/select-script.blade.php
+++ b/resources/views/includes/select-script.blade.php
@@ -1,0 +1,38 @@
+<script>
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('lfbStyledSelect', (config) => ({
+        search: '',
+        selected: config.preselected,
+        placeholder: '{{ __('Please select...') }}',
+        data: config.data,
+        show: false,
+        filteredOptions() {
+            return this.data.filter((item) => {
+                return item.label.toLowerCase().includes(this.search.toLowerCase());
+            });
+        },
+        selectOption(value) {
+            this.selected = value;
+            this.resetSearch();
+            this.close();
+        },
+        removeSelected() {
+            this.selected = '';
+        },
+        resetSearch() {
+            this.search = '';
+        },
+        open() {
+            this.show = true;
+            this.resetSearch();
+        },
+        close() {
+            this.show = false;
+        },
+        toggle() {
+            this.show = !this.show;
+        },
+    }))
+})
+</script>

--- a/resources/views/includes/select-script.blade.php
+++ b/resources/views/includes/select-script.blade.php
@@ -1,24 +1,34 @@
 <script>
 
 document.addEventListener('alpine:init', () => {
-    Alpine.data('lfbStyledSelect', (config) => ({
+    Alpine.data('lfbStyledSelect', (options) => ({
         search: '',
-        selected: config.preselected,
+        selectedLabel() {
+            if (this.value) {
+                const selectedItem = this.options.find((item) => {
+                    return item.value === this.value;
+                });
+                if (selectedItem) {
+                    return selectedItem.label;
+                }
+            }
+            return '';
+        },
         placeholder: '{{ __('Please select...') }}',
-        data: config.data,
+        options: options,
         show: false,
         filteredOptions() {
-            return this.data.filter((item) => {
+            return this.options.filter((item) => {
                 return item.label.toLowerCase().includes(this.search.toLowerCase());
             });
         },
-        selectOption(value) {
-            this.selected = value;
+        selectOption(item) {
+            this.value = item.value;
             this.resetSearch();
             this.close();
         },
         removeSelected() {
-            this.selected = '';
+            this.value = null;
         },
         resetSearch() {
             this.search = '';


### PR DESCRIPTION
* allow html in component labels (thereby extracting the label part to an include)
* introduce html/div based select with optional client side/JavaScript search
  * realised as properties for the existing select form field
  * does not yet support grouped selects and customisable icons (chevron, remove, search), I think this can be added later when needed
  * I needed to adjust the Livewire data binding from the existing example (using dispatch) to `@entangle` since I got JavaScript errors when using the search after a previous select.

So far only tested with a local test app.