### PR TITLE
Bugfix styled select JavaScript init

### DIFF
--- a/resources/views/includes/select-script.blade.php
+++ b/resources/views/includes/select-script.blade.php
@@ -1,6 +1,6 @@
 <script>
 
-document.addEventListener('alpine:init', () => {
+const initStyledSelect = () => {
     Alpine.data('lfbStyledSelect', (options) => ({
         search: '',
         selectedLabel() {
@@ -44,5 +44,11 @@ document.addEventListener('alpine:init', () => {
             this.show = !this.show;
         },
     }))
-})
+};
+
+if (typeof Alpine !== 'undefined') {
+    initStyledSelect();
+} else {
+    document.addEventListener('alpine:init', initStyledSelect);
+}
 </script>


### PR DESCRIPTION
After integrating into a project, I discovered a bug with the new styled select logic for the case when the form is rendered dynamically to an existing page where Alpine js is already initialised. The change in this PR fixes that.