### PR TITLE
Bugfix: Trix multiple editors

### DIFF
--- a/resources/views/components/trix-editor.blade.php
+++ b/resources/views/components/trix-editor.blade.php
@@ -11,7 +11,10 @@
             </div>
 
             <script>
-                document.querySelector('trix-editor').editor.element.setAttribute('contentEditable', false)
+                document.addEventListener("DOMContentLoaded", function () {
+                    const readonlyEditor = document.querySelector('trix-editor[input="trix-editor-input-content-{{ $key }}"]');
+                    readonlyEditor.editor.element.setAttribute('contentEditable', false);
+                });
             </script>
             @include('lara-forms-builder::includes.field-form-warning')
         </div>
@@ -26,11 +29,14 @@
             </div>
 
             <script>
-                let trixEditor_{{ $key }} = document.getElementById("trix-editor-input-content-{{ $key }}")
+                document.addEventListener("DOMContentLoaded", function () {
+                    const input = document.getElementById("trix-editor-input-content-{{ $key }}");
+                    const editor = document.querySelector('trix-editor[input="trix-editor-input-content-{{ $key }}"]');
 
-                document.addEventListener("trix-change", function(event) {
-                    @this.set("formProperties.{{ $key }}", trixEditor_{{ $key }}.getAttribute('value'));
-                })
+                    editor.addEventListener("trix-change", function () {
+                        @this.set("formProperties.{{ $key }}", input.value);
+                    });
+                });
             </script>
             @include('lara-forms-builder::includes.field-error-message')
             @include('lara-forms-builder::includes.field-form-warning')

--- a/src/Commands/LaraFormsBuilderSetupCommand.php
+++ b/src/Commands/LaraFormsBuilderSetupCommand.php
@@ -62,7 +62,7 @@ class LaraFormsBuilderSetupCommand extends Command
     protected function checkEnvironment(): void
     {
         Log::info('LFB Jetstream = '.InstalledVersions::isInstalled('laravel/jetstream'));
-        //check if jetstream version 4 installed
+        // check if jetstream version 4 installed
         if (InstalledVersions::isInstalled('laravel/jetstream')) {
             $jetstreamVersion = InstalledVersions::getVersion('laravel/jetstream');
             $jetstreamVersionAsArray = collect(explode('.', $jetstreamVersion))->slice(0, 1)->toArray();
@@ -88,7 +88,7 @@ class LaraFormsBuilderSetupCommand extends Command
             );
         }
 
-        //check if pikaday & moment npm packages installed
+        // check if pikaday & moment npm packages installed
         if (File::exists(base_path('package.json'))) {
             $data = json_decode(file_get_contents(base_path('package.json')), true);
             // check dependencies{} object


### PR DESCRIPTION
Fixes issues with multiple Trix editors on the same page by scoping event listeners and read-only settings to each instance. Prevents value conflicts and ensures proper Livewire syncing per editor.