### PR TITLE
Fix phpstan workflow errors

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,4 +26,9 @@ jobs:
         uses: ramsey/composer-install@v3
 
       - name: Run PHPStan
-        run: ./vendor/bin/phpstan --error-format=github
+        run: |
+          if [[ "${{ matrix.php }}" == "8.1" ]]; then
+            ./vendor/bin/phpstan analyse -c phpstan.neon81.dist --error-format=github
+          else
+            ./vendor/bin/phpstan analyse -c phpstan.neon.dist --error-format=github
+          fi

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,3 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,3 +9,9 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
+    ignoreErrors:
+        -
+            message: '#Trait [a-zA-Z0-9\\_]+ is used zero times and is not analysed.#'
+            paths:
+                - %currentWorkingDirectory%/src/Traits/HasTabs.php
+                - %currentWorkingDirectory%/src/Traits/MultiStepForm.php

--- a/phpstan.neon81.dist
+++ b/phpstan.neon81.dist
@@ -1,0 +1,11 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 4
+    paths:
+        - src
+        - config
+    tmpDir: build/phpstan
+    checkOctaneCompatibility: true
+    checkModelProperties: true

--- a/src/LaraFormsBuilder.php
+++ b/src/LaraFormsBuilder.php
@@ -114,6 +114,7 @@ trait LaraFormsBuilder
 
     private function getFieldRulesAndValidationAttributes(): array
     {
+        // @phpstan-ignore-next-line
         $modelRules = get_class($this->model)::$rules ?? [];
         $fieldRules = [];
         $fieldValidationAttributes = [];
@@ -196,6 +197,7 @@ trait LaraFormsBuilder
         $this->fields = $this->fields();
 
         if ($this->isMultiStepForm()) {
+            // @phpstan-ignore-next-line
             $this->initSteps();
         }
     }


### PR DESCRIPTION
- Remove unsupported phpstan parameter, Ref: https://github.com/phpstan/phpstan/blob/a8a45d3e1a0ec3cc61aea0f29e8bcefd7a44e29e/UPGRADING.md?plain=1#L44
- Adjust phpstan workflow when running on PHP 8.1 since the 'trait.unused' error is not caught