### PR TITLE
Fix default button position in Lara Forms Builder

### DIFF
--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -23,7 +23,7 @@
         </div>
     @enderror
     @if (!isset($hasTabs) || (isset($hasTabs) && !$hasTabs))
-        @include('lara-forms-builder::includes.buttons')
+        @include('lara-forms-builder::includes.buttons', ['position' => 'bottom'])
     @endif
     @if($scrollToFirstError)
        @include('lara-forms-builder::includes.scroll-to-first-error-script')

--- a/resources/views/includes/buttons.blade.php
+++ b/resources/views/includes/buttons.blade.php
@@ -1,7 +1,4 @@
-@php
-    $position = $position ?? 'top';
-@endphp
-<div class="{{ $position === 'top' ? $this->getHeaderButtonsWrapperClasses() : $this->getFooterButtonsWrapperClasses() }}">
+<div class="{{ ($position ?? 'bottom') === 'top' ? $this->getHeaderButtonsWrapperClasses() : $this->getFooterButtonsWrapperClasses() }}">
     <div class="lfb-buttons @if($this->isMultiStepForm() && $this->activeStepNumber() > 1)lfb-multi-step-buttons @endif">
         @if ($this->isMultiStepForm())
             @if ($this->activeStepNumber() > 1)


### PR DESCRIPTION
### Problem
In buttons.blade.php, the @php block at the beginning of the template assigned $position in the local scope:

```php
@php
    $position = $position ?? 'top';
@endphp
```
This caused a bug: when the template was included twice in `tabs.blade.php `(once with `position => 'top'` for the optional top navigation, and once with `position => 'bottom'` for the footer), the `$position` variable could be overwritten by Blade due to how get_defined_vars() is captured and passed to `@include` directives. As a result, footer buttons received the header CSS classes (`lfb-header-buttons-wrapper` instead of `lfb-buttons-wrapper`).

### Solution
Two changes were applied:

1. Removed the @php block and inlined the null coalescing operator (buttons.blade.php)
The @php block was removed. The default value is now resolved directly in the Blade expression, without modifying any variable in scope: 
```php 
<div class="{{ ($position ?? 'bottom') === 'top' ? ... : ... }}">
```
2. Made the position parameter explicit in the @include within form.blade.php
The button include for forms without tabs now explicitly passes the position parameter, aligning with reality: buttons belong at the bottom of the form.
```php 
@include('lara-forms-builder::includes.buttons', ['position' => 'bottom'])
```