### PR TITLE
Add navigation functionality for multi-step form

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,101 @@ public function getNextStepIcon(): ?string
 }
 ```
 
+##### Step Navigation, Guards & Validity
+
+By default a multi-step form is a forward-only wizard: `Next` validates the
+current step, `Previous` does not, and the step nav is display-only. All of the
+behaviour below is **opt-in** — enable it per-form via public properties (set
+as class properties or through `mountForm([...])`, like `showStepNumber`)
+without affecting other forms.
+
+```php
+$this->mountForm($model, [
+    'isMultiStep'                         => true,
+    'isJumpingBetweenStepsEnabled'        => false, // clickable step nav (jump to any step)
+    'shouldValidateCurrentStepOnNext'     => true,  // validate the current step on Next
+    'shouldValidateCurrentStepOnPrevious' => false, // validate the current step on Previous
+    'shouldValidateCurrentStepOnJump'     => true,  // validate the current step when jumping
+]);
+```
+
+**Free navigation (jumping).** With `$isJumpingBetweenStepsEnabled` enabled the step nav
+becomes clickable and calls `goToStep($key)`. To decide it per-form (e.g. only
+when editing an existing record), set the property from `mount()`:
+
+```php
+$this->mountForm($model, [
+    'isMultiStep'                  => true,
+    'isJumpingBetweenStepsEnabled' => true,
+]);
+```
+
+**Navigation guards & hooks.** `nextStep()`, `previousStep()` and `goToStep()`
+all funnel through one pipeline. Override any of these to customise navigation
+— you never need to alias or re-implement the navigation methods themselves:
+
+| Method                                  | Returns | Default                                                                                                                                                                                |
+|-----------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `canLeaveStep($from, $to, $direction)`  | `bool`  | Validate `$from` (per `shouldValidateOnLeave`) + run `extraValidate()`; return `false` to block.                                                                                       |
+| `shouldValidateOnLeave($direction)`     | `bool`  | `forward` → `$shouldValidateCurrentStepOnNext`; `backward` → `$shouldValidateCurrentStepOnPrevious`; `jump` → `$shouldValidateCurrentStepOnJump` (Back/Jump forced off in create mode) |
+| `onStepChanged($from, $to, $direction)` | `void`  | `refreshSteps()`, recompute statuses, scroll to top                                                                                                                                    |
+
+`$direction` is one of `forward`, `backward`, `jump`.
+
+**Create mode is a strict forward wizard.** In create mode the package auto-disables the
+view/edit-only features regardless of their flags: step jumping is off, error badges are
+not shown, and only `Next` validation runs (Back/Jump validation are skipped). All of them
+take effect once the record exists (view/edit).
+
+**Per-step validity & error badges.** The component exposes `$stepStatuses` — a
+plain map `['step-key' => bool]` (true = valid), recomputed on navigation for
+existing records (skipped in create mode, so a fresh form isn't all red).
+Invalid steps receive the `lfb-step-nav-title-error` class in the nav and a
+default error icon (override `getStepErrorIcon()` to customise it, or return
+null for none). Define step-level rules — including "at least one selected"
+checks — by overriding
+`isStepValid()`, the single source of truth for step validity. It lives in the
+trait, so to reuse the base rules alias the trait method rather than using
+`parent::`:
+
+```php
+use HasTabs, MultiStepForm {
+    MultiStepForm::isStepValid as baseIsStepValid;
+}
+
+protected function isStepValid(string $key): bool
+{
+    if (! $this->baseIsStepValid($key)) {   // base rules for this step
+        return false;
+    }
+
+    if ($key === 'contacts-step' && ! $otherCondition) {
+        return false;
+    }
+
+    return true;
+}
+```
+
+**Derived steps (content that depends on other steps).** When a step's fields
+depend on answers from an earlier step, regenerate only that step inside
+`refreshSteps()` using `rebuildStepFields()` — this leaves every other step
+(and any repeater rows they contain) untouched:
+
+```php
+protected function refreshSteps(string $to, string $from, string $direction): void
+{
+    if ($to === 'contacts-step') {
+        $this->rebuildStepFields('contacts-step', $this->contactsStepFields());
+    }
+}
+```
+
+**Save orchestration.** For a multi-step form, `submit()` always validates every
+step before saving — so a rule on a non-active step can't be bypassed. If any
+step is invalid it jumps to the first one, surfaces its errors, and blocks the
+save; otherwise it saves.
+
 ---
 
 ### Form Methods

--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ all funnel through one pipeline. Override any of these to customise navigation
 |-----------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `canLeaveStep($from, $to, $direction)`  | `bool`  | Validate `$from` (per `shouldValidateOnLeave`) + run `extraValidate()`; return `false` to block.                                                                                       |
 | `shouldValidateOnLeave($direction)`     | `bool`  | `forward` → `$shouldValidateCurrentStepOnNext`; `backward` → `$shouldValidateCurrentStepOnPrevious`; `jump` → `$shouldValidateCurrentStepOnJump` (Back/Jump forced off in create mode) |
-| `onStepChanged($from, $to, $direction)` | `void`  | `refreshSteps()`, recompute statuses, scroll to top                                                                                                                                    |
+| `onStepChanged($from, $to, $direction)` | `void`  | `refreshSteps()`, recompute status badges (only when the direction validates, per `shouldValidateOnLeave`), scroll to top                                                             |
 
 `$direction` is one of `forward`, `backward`, `jump`.
 
@@ -1036,7 +1036,9 @@ take effect once the record exists (view/edit).
 
 **Per-step validity & error badges.** The component exposes `$stepStatuses` — a
 plain map `['step-key' => bool]` (true = valid), recomputed on navigation for
-existing records (skipped in create mode, so a fresh form isn't all red).
+existing records — only on directions that validate (so leaving a step without
+re-validating, e.g. Previous, keeps the current badges), and skipped in create
+mode so a fresh form isn't all red.
 Invalid steps receive the `lfb-step-nav-title-error` class in the nav and a
 default error icon (override `getStepErrorIcon()` to customise it, or return
 null for none). Define step-level rules — including "at least one selected"

--- a/resources/dist/css/lara-forms-builder.css
+++ b/resources/dist/css/lara-forms-builder.css
@@ -294,6 +294,14 @@
         @apply bg-gray-200/50 border-gray-300;
     }
 
+    .lfb-step-nav-title-btn {
+        @apply cursor-pointer hover:bg-gray-100;
+    }
+
+    .lfb-step-nav-title-error {
+        @apply text-red-600 border-red-300;
+    }
+
     .lfb-tab-content-wrapper {
         @apply lg:col-span-10 relative pb-4;
     }

--- a/resources/views/includes/tabs.blade.php
+++ b/resources/views/includes/tabs.blade.php
@@ -7,7 +7,7 @@
                     <nav class="lfb-steps-nav">
                         @php
                             $lfbStepStatuses = property_exists($this, 'stepStatuses') ? $this->stepStatuses : [];
-                            $lfbCanJumpSteps = property_exists($this, 'isJumpingBetweenStepsEnabled') && $this->isJumpingBetweenStepsEnabled && $this->mode !== 'create';
+                            $lfbCanJumpSteps = method_exists($this, 'canJumpBetweenSteps') && $this->canJumpBetweenSteps();
                         @endphp
                         @foreach($fields as $index => $field)
                             @php

--- a/resources/views/includes/tabs.blade.php
+++ b/resources/views/includes/tabs.blade.php
@@ -5,14 +5,33 @@
             <aside class="lfb-steps-nav-wrapper">
                 <div class="lfb-steps-nav-container">
                     <nav class="lfb-steps-nav">
+                        @php
+                            $lfbStepStatuses = property_exists($this, 'stepStatuses') ? $this->stepStatuses : [];
+                            $lfbCanJumpSteps = property_exists($this, 'isJumpingBetweenStepsEnabled') && $this->isJumpingBetweenStepsEnabled && $this->mode !== 'create';
+                        @endphp
                         @foreach($fields as $index => $field)
+                            @php
+                                $lfbStepKey = $field['key'];
+                                $lfbStepInvalid = ! ($lfbStepStatuses[$lfbStepKey] ?? true);
+                            @endphp
                             <div class="lfb-step-nav">
-                                <div x-bind:class="[ tab == '{{ $field['key'] }}' ? 'lfb-step-nav-title-active' : '']" class="lfb-step-nav-title">
+                                <div
+                                    x-bind:class="[ tab == '{{ $lfbStepKey }}' ? 'lfb-step-nav-title-active' : '']"
+                                    @class([
+                                        'lfb-step-nav-title',
+                                        'lfb-step-nav-title-btn' => $lfbCanJumpSteps,
+                                        'lfb-step-nav-title-error' => $lfbStepInvalid,
+                                    ])
+                                    @if($lfbCanJumpSteps) wire:click="goToStep('{{ $lfbStepKey }}')" @endif
+                                >
                                     @if(property_exists($this, 'showStepNumber') && $this->showStepNumber)
                                         <span class="lfb-step-nav-number">{{ $index + 1 }}</span>
                                     @endif
                                     <div class="lfb-step-nav-label">
                                         {{ $field['navTitle'] ?? $field['title'] }}
+                                        @if($lfbStepInvalid)
+                                            {!! $this->getStepErrorIcon() !!}
+                                        @endif
                                     </div>
                                 </div>
                             </div>

--- a/src/LaraFormsBuilder.php
+++ b/src/LaraFormsBuilder.php
@@ -337,6 +337,11 @@ trait LaraFormsBuilder
             $this->dispatch('scroll-to-first-error');
         }
 
+        // Multi-step: validate every step before saving; runs before validate() so it can route to the first invalid step.
+        if ($this->isMultiStepForm() && ! $this->validateAllStepsBeforeSave()) {
+            return false;
+        }
+
         $validatedData = $this->validate();
 
         $validatedData = $validatedData['formProperties'];

--- a/src/Traits/MultiStepForm.php
+++ b/src/Traits/MultiStepForm.php
@@ -13,21 +13,64 @@ trait MultiStepForm
     public bool $multiStepNavigationIconsEnabled = false;
 
     /**
+     * Multi-step navigation options — set per-form via mountForm([...]) or as
+     * class properties. Create mode is always a strict forward wizard, so
+     * jumping, error badges, and Back/Jump validation are auto-disabled there;
+     * these options only take effect in view/edit mode.
+     */
+    public bool $isJumpingBetweenStepsEnabled = false;
+
+    public bool $shouldValidateCurrentStepOnNext = true;
+
+    public bool $shouldValidateCurrentStepOnPrevious = false;
+
+    public bool $shouldValidateCurrentStepOnJump = true;
+
+    // Per-step validity snapshot [ 'step-key' => bool ] (true = valid); drives the nav error indicators. Filled on navigation except in create mode.
+    public array $stepStatuses = [];
+
+    /**
      * Initialize the steps
      */
     protected function initSteps(array $steps = []): void
     {
-        if (empty($steps)) {
-            $this->steps = collect($this->fields)->map(function ($tab) {
-                return [
-                    'key' => $tab['key'],
-                    'title' => $tab['title'],
-                    'fields' => $tab['content']['fields'],
-                ];
-            })->toArray();
-        } else {
+        if ($steps !== []) {
             $this->steps = $steps;
+
+            return;
         }
+
+        $this->steps = collect($this->fields)->map(function ($tab) {
+            return [
+                'key' => $tab['key'],
+                'title' => $tab['title'],
+                'fields' => $this->extractStepFields($tab),
+            ];
+        })->toArray();
+    }
+
+    /**
+     * Extract the flat field list for a single tab definition.
+     * Supports both a single group (content['fields']) and multiple groups (content is an array of groups, each with its own 'fields').
+     */
+    protected function extractStepFields(array $tab): array
+    {
+        // Single group: content has a 'fields' array directly
+        if (isset($tab['content']['fields']) && is_array($tab['content']['fields'])) {
+            return $tab['content']['fields'];
+        }
+
+        // Multiple groups: merge every group's 'fields'
+        $fields = [];
+        if (is_array($tab['content'] ?? null)) {
+            foreach ($tab['content'] as $group) {
+                if (is_array($group) && isset($group['fields']) && is_array($group['fields'])) {
+                    $fields = array_merge($fields, $group['fields']);
+                }
+            }
+        }
+
+        return $fields;
     }
 
     /**
@@ -61,47 +104,259 @@ trait MultiStepForm
     }
 
     /**
+     * Resolve the step key for a 1-based step number.
+     * $this->steps is a 0-based array, activeStepNumber is 1-based, so the
+     * mapping (and only here) crosses those two index spaces. Returns null
+     * when the number falls outside the available steps.
+     */
+    protected function stepKeyAt(int $stepNumber): ?string
+    {
+        return $this->steps[$stepNumber - 1]['key'] ?? null;
+    }
+
+    /**
      * previous step
      */
     public function previousStep(): void
     {
-        $this->activeStepNumber--;
-        $this->activeTab = $this->steps[$this->activeStepNumber - 1]['key'];
-        if ($this->mode == 'confirm') {
-            $this->mode = null;
+        if (($key = $this->stepKeyAt($this->activeStepNumber - 1)) !== null) {
+            $this->changeStep($key, 'backward');
         }
-        $this->dispatch('scroll-to-top-form');
     }
 
     /**
      * next step
      */
-    public function nextStep()
+    public function nextStep(): void
     {
+        if ($key = $this->stepKeyAt($this->activeStepNumber + 1)) {
+            $this->changeStep($key, 'forward');
+        }
+    }
+
+    /**
+     * Jump directly to an arbitrary step by key.
+     */
+    public function goToStep(string $stepKey): void
+    {
+        $this->changeStep($stepKey, 'jump');
+    }
+
+    /**
+     * The single navigation pipeline shared by next/previous/goToStep.
+     * Runs the guard hook canLeaveStep(), performs the switch, then the after-change hook onStepChanged().
+     */
+    protected function changeStep(string $to, string $direction): void
+    {
+        $from = $this->activeTab;
+
+        if ($to === '' || $to === $from) {
+            return;
+        }
+
+        if (! $this->canLeaveStep($from, $to, $direction)) {
+            return;
+        }
+
+        $this->activeTab = $to;
+        $this->setActiveStepNumber($to);
+
+        // Leaving a step in any non-forward direction exits confirmation mode.
+        if ($direction !== 'forward' && $this->mode === 'confirm') {
+            $this->mode = null;
+        }
+
+        $this->onStepChanged($from, $to, $direction);
+    }
+
+    /**
+     * Guard: may the user leave the current step for $to?
+     * Default: when validation is required for this direction, validate the
+     * step's own base rules and run extraValidate(); return false to block.
+     * Override for custom leave rules.
+     */
+    protected function canLeaveStep(string $from, string $to, string $direction): bool
+    {
+        if (! $this->shouldValidateOnLeave($direction)) {
+            return true;
+        }
+
         if ($this->scrollToFirstError) {
             $this->dispatch('scroll-to-first-error');
         }
 
-        // validate the current step
-        $validatedData = $this->validate(
-            array_intersect_key(
-                $this->rules,
-                array_flip(
-                    array_map(fn ($element) => 'formProperties.'.$element,
-                        array_keys($this->steps[$this->activeStepNumber - 1]['fields'])
-                    )
-                )
-            )
-        );
+        return $this->validateCurrentStep();
+    }
 
-        $validatedData = $validatedData['formProperties'];
+    /**
+     * Validate the CURRENT step: runs Livewire's validate() (which throws + renders errors on base-rule failure) and extraValidate() (which writes the error/warning bag).
+     */
+    protected function validateCurrentStep(): bool
+    {
+        $validatedData = $this->validate($this->stepValidationRules($this->activeTab))['formProperties'] ?? [];
 
-        if (! $this->extraValidate($validatedData)) {
-            return false;
-        }
-        $this->activeStepNumber = $this->activeStepNumber + 1;
-        $this->activeTab = $this->steps[$this->activeStepNumber - 1]['key'];
+        return $this->extraValidate($validatedData);
+    }
+
+    /**
+     * Hook: runs right after the active step has changed.
+     * Default: regenerate any derived step content, refresh the status snapshot, and scroll to the top of the form.
+     */
+    protected function onStepChanged(string $from, string $to, string $direction): void
+    {
+        $this->refreshSteps($to, $from, $direction);
+        $this->refreshStepStatuses();
         $this->dispatch('scroll-to-top-form');
+    }
+
+    /**
+     * Hook: regenerate step content that depends on another step's answers.
+     * Default no-op. Override and call rebuildStepFields() to rebuild only the
+     * affected step (leaving other steps' fields untouched).
+     */
+    protected function refreshSteps(string $to, string $from, string $direction): void {}
+
+    /**
+     * Rebuild a single step's definition in place — updates only the matching
+     * tab in $this->fields and its $this->steps entry, so every other step keeps
+     * its current (possibly repeater-expanded) fields. Prefer this over a whole
+     * $this->fields rebuild.
+     */
+    protected function rebuildStepFields(string $stepKey, array $tabDefinition): void
+    {
+        foreach ($this->fields as $index => $tab) {
+            if (($tab['key'] ?? null) === $stepKey) {
+                $this->fields[$index] = $tabDefinition;
+                break;
+            }
+        }
+
+        foreach ($this->steps as $index => $step) {
+            if (($step['key'] ?? null) === $stepKey) {
+                $this->steps[$index] = [
+                    'key' => $tabDefinition['key'],
+                    'title' => $tabDefinition['title'] ?? ($step['title'] ?? null),
+                    'fields' => $this->extractStepFields($tabDefinition),
+                ];
+                break;
+            }
+        }
+    }
+
+    /**
+     * Field keys belonging to a step, resolved by step key.
+     */
+    protected function stepFieldKeys(string $stepKey): array
+    {
+        foreach ($this->steps as $step) {
+            if (($step['key'] ?? null) === $stepKey) {
+                return array_keys($step['fields'] ?? []);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * The subset of $this->rules that applies to a given step's fields.
+     */
+    protected function stepValidationRules(string $stepKey): array
+    {
+        return array_intersect_key(
+            $this->rules,
+            array_flip(array_map(
+                fn ($key) => 'formProperties.'.$key,
+                $this->stepFieldKeys($stepKey)
+            ))
+        );
+    }
+
+    /**
+     * Whether a step is valid — pure/read-only (no throw, no error bag, no state mutation),
+     * So it is safe to call for every step from anywhere (drives the nav error indicators).
+     */
+    protected function isStepValid(string $stepKey): bool
+    {
+        return ! app('validator')->make(
+            ['formProperties' => $this->formProperties],
+            $this->stepValidationRules($stepKey)
+        )->fails();
+    }
+
+    /**
+     * Build the per-step validity snapshot: [ 'step-key' => bool ] (true = valid).
+     */
+    public function resolveStepStatuses(): array
+    {
+        $statuses = [];
+        foreach ($this->steps as $step) {
+            $statuses[$step['key']] = $this->isStepValid($step['key']);
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * Refresh $this->stepStatuses (or clear it when disabled).
+     */
+    protected function refreshStepStatuses(): void
+    {
+        // Skip on create mode — a fresh, untouched form should not show every step red.
+        $this->stepStatuses = $this->mode !== 'create'
+            ? $this->resolveStepStatuses()
+            : [];
+    }
+
+    /**
+     * Validate every step before saving so a rule on a non-active step cannot be
+     * bypassed. On the first invalid step, routes to it and surfaces its errors,
+     * then returns false to block the save; returns true when all steps pass.
+     * Called by submit() for multi-step forms.
+     */
+    protected function validateAllStepsBeforeSave(): bool
+    {
+        $statuses = $this->resolveStepStatuses();
+
+        // Keep the nav badges in sync with this save-time validation.
+        if ($this->mode !== 'create') {
+            $this->stepStatuses = $statuses;
+        }
+
+        $invalidSteps = array_keys(array_filter($statuses, fn ($valid) => ! $valid));
+
+        if ($invalidSteps === []) {
+            return true;
+        }
+
+        // Route to the first invalid step, then surface its errors there
+        // (extraValidate() keys off the now-active step).
+        $target = $invalidSteps[0];
+
+        if ($this->activeTab !== $target) {
+            $from = $this->activeTab;
+            $this->activeTab = $target;
+            $this->setActiveStepNumber($target);
+            $this->refreshSteps($target, $from, 'jump');
+        }
+
+        $this->validateCurrentStep();
+
+        return false;
+    }
+
+    /**
+     * Whether leaving the current step validates it first, per direction.
+     */
+    protected function shouldValidateOnLeave(string $direction): bool
+    {
+        // Create mode is a strict forward wizard: validate only on Next; Back and
+        // Jump validation are view/edit-only (and jumping is disabled on create).
+        return match ($direction) {
+            'forward' => $this->shouldValidateCurrentStepOnNext,
+            'backward' => $this->mode !== 'create' && $this->shouldValidateCurrentStepOnPrevious,
+            'jump' => $this->mode !== 'create' && $this->shouldValidateCurrentStepOnJump,
+            default => true,
+        };
     }
 
     /**
@@ -164,5 +419,15 @@ trait MultiStepForm
         }
 
         return null;
+    }
+
+    /**
+     * SVG icon shown on invalid steps in the nav (uses currentColor, so the
+     * .lfb-step-nav-title-error styling colours it). Can be overridden in the
+     * form controller; return null to show no icon.
+     */
+    public function getStepErrorIcon(): ?string
+    {
+        return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-5 h-5 flex-shrink-0"><path d="M7.005 3.1a1 1 0 1 1 1.99 0l-.388 6.35a.61.61 0 0 1-1.214 0zM7 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0" /></svg>';
     }
 }

--- a/src/Traits/MultiStepForm.php
+++ b/src/Traits/MultiStepForm.php
@@ -129,7 +129,7 @@ trait MultiStepForm
      */
     public function nextStep(): void
     {
-        if ($key = $this->stepKeyAt($this->activeStepNumber + 1)) {
+        if (($key = $this->stepKeyAt($this->activeStepNumber + 1)) !== null) {
             $this->changeStep($key, 'forward');
         }
     }
@@ -139,7 +139,18 @@ trait MultiStepForm
      */
     public function goToStep(string $stepKey): void
     {
-        $this->changeStep($stepKey, 'jump');
+        if ($this->canJumpBetweenSteps()) {
+            $this->changeStep($stepKey, 'jump');
+        }
+    }
+
+    /**
+     * Check if free step jumping is allowed. Used by goToStep() and
+     * the step-nav view.
+     */
+    public function canJumpBetweenSteps(): bool
+    {
+        return $this->isJumpingBetweenStepsEnabled && $this->mode !== 'create';
     }
 
     /**
@@ -286,7 +297,7 @@ trait MultiStepForm
     /**
      * Build the per-step validity snapshot: [ 'step-key' => bool ] (true = valid).
      */
-    public function resolveStepStatuses(): array
+    protected function resolveStepStatuses(): array
     {
         $statuses = [];
         foreach ($this->steps as $step) {

--- a/src/Traits/MultiStepForm.php
+++ b/src/Traits/MultiStepForm.php
@@ -211,12 +211,18 @@ trait MultiStepForm
 
     /**
      * Hook: runs right after the active step has changed.
-     * Default: regenerate any derived step content, refresh the status snapshot, and scroll to the top of the form.
+     * Default: regenerate any derived step content, refresh the status snapshot
+     * (only for directions we validate on — a direction that skips validation,
+     * e.g. Previous, keeps the existing badges), and scroll to the top of the form.
      */
     protected function onStepChanged(string $from, string $to, string $direction): void
     {
         $this->refreshSteps($to, $from, $direction);
-        $this->refreshStepStatuses();
+
+        if ($this->shouldValidateOnLeave($direction)) {
+            $this->refreshStepStatuses();
+        }
+
         $this->dispatch('scroll-to-top-form');
     }
 


### PR DESCRIPTION
This PR serves to add multi-step navigation functionality for the form. These are the main points:

1. Make that configurable and disabled by default.
2. Update `tabs` blade
3. And a central function for navigation `changeStep()`, and it is called by `nextStep()`, `previousStep()`, and the new `goToStep()`
4. Resolve step status on every navigation action to display a badge error
5. Update `initSteps()` to resolve if the tab contains multiple groups of fields
6. Add `refreshSteps()` that provides the ability for developers to take action (if needed) after a step change
7. Add `rebuildStepFields()` to be called within the application if there is a need to rebuild the fields instead of using `$this->fields = $this->fields();`